### PR TITLE
remove shadowDatabaseUrl

### DIFF
--- a/pages/development-guides/generated-applications/app-deployment.mdx
+++ b/pages/development-guides/generated-applications/app-deployment.mdx
@@ -146,7 +146,6 @@ datasource db {
   provider = "postgresql"
   url = env("POSTGRES_PRISMA_URL") // uses connection pooling
   directUrl = env("POSTGRES_URL_NON_POOLING") // uses a direct connection
-  shadowDatabaseUrl = env("POSTGRES_URL_NON_POOLING") // used for migrations
 }
 ```
 


### PR DESCRIPTION
`shadowDatabaseUrl` is no longer required for Vercel Postgres and may cause issues when set to the same value as `directUrl`.